### PR TITLE
Remove the Error::cause

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -60,10 +60,6 @@ impl error::Error for AudioReadError {
 			&AudioReadError::BufferNotAddressable => "Requested to create buffer of non-addressable size",
 		}
 	}
-
-	fn cause(&self) -> Option<&error::Error> {
-		None
-	}
 }
 
 impl fmt::Display for AudioReadError {

--- a/src/header.rs
+++ b/src/header.rs
@@ -105,10 +105,6 @@ impl error::Error for HeaderReadError {
 			&HeaderReadError::BufferNotAddressable => "Requested to create buffer of non-addressable size",
 		}
 	}
-
-	fn cause(&self) -> Option<&error::Error> {
-		None
-	}
 }
 
 impl fmt::Display for HeaderReadError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,10 +116,6 @@ impl std::error::Error for VorbisError {
 			&VorbisError::OggError(ref e) => e.description(),
 		}
 	}
-
-	fn cause(&self) -> Option<&std::error::Error> {
-		None
-	}
 }
 
 impl std::fmt::Display for VorbisError {


### PR DESCRIPTION
It is deprecated since 1.33.0 and it has a default impl.