### PR TITLE
Capi using cargo c

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,3 @@ features = ["async_ogg"]
 
 [lib]
 name = "lewton"
-crate-type = ["lib", "cdylib"]

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -60,10 +60,6 @@ impl error::Error for AudioReadError {
 			&AudioReadError::BufferNotAddressable => "Requested to create buffer of non-addressable size",
 		}
 	}
-
-	fn cause(&self) -> Option<&error::Error> {
-		None
-	}
 }
 
 impl fmt::Display for AudioReadError {

--- a/src/header.rs
+++ b/src/header.rs
@@ -105,10 +105,6 @@ impl error::Error for HeaderReadError {
 			&HeaderReadError::BufferNotAddressable => "Requested to create buffer of non-addressable size",
 		}
 	}
-
-	fn cause(&self) -> Option<&error::Error> {
-		None
-	}
 }
 
 impl fmt::Display for HeaderReadError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,10 +116,6 @@ impl std::error::Error for VorbisError {
 			&VorbisError::OggError(ref e) => e.description(),
 		}
 	}
-
-	fn cause(&self) -> Option<&std::error::Error> {
-		None
-	}
 }
 
 impl std::fmt::Display for VorbisError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // at your option. Please see the LICENSE file
 // attached to this source distribution for details.
 
-#![forbid(unsafe_code)]
+#![cfg_attr(not(cargo_c), forbid(unsafe_code))]
 #![cfg_attr(test, deny(warnings))]
 
 /*!
@@ -250,3 +250,76 @@ fn print_f64_slice(arr :&[f64]) {
 		de => panic!("impossible value {}", de),
 	}
 }
+
+#[cfg(cargo_c)]
+pub mod capi {
+	use std::os::raw::c_int;
+
+	/// Main Decoder State
+	///
+	/// It is created by `lewton_context_from_extradata` by passing a xiph-laced extradate bundle
+	pub struct LewtonContext {
+
+	}
+
+	/// A multichannel vector of samples
+	///
+	/// It is produced by `lewton_decode_packet`
+	///
+	/// Use `lewton_samples_count` to retrieve the number of samples available in each channel
+	/// Use `lewton_samples_channels` to retrieve the number of channels
+	/// Use `lewton_samples_for_channel_f32` to retrieve a reference to the data present in the
+	/// channel
+	///
+	/// use `lewton_samples_drop()` to deallocate the memory
+	pub struct LewtonSamples {
+
+	}
+
+	/// Create a LewtonContext from an extradata buffer
+	///
+	/// Returns either NULL or a newly allocated LewtonContext
+	#[no_mangle]
+	pub unsafe extern "C" fn lewton_context_from_extradata(data: *const u8, len: usize) -> *mut LewtonContext {
+		unimplemented!()
+	}
+
+	/// Reset the Decoder to support seeking.
+	#[no_mangle]
+	pub unsafe extern "C" fn lewton_context_reset(ctx: *mut LewtonContext) {
+		unimplemented!()
+	}
+
+	/// Decode a packet to LewtonSamples when possible
+	///
+	/// Returns 0 on success, non-zero if no samples can be produced
+	#[no_mangle]
+    pub unsafe extern "C" fn lewton_decode_packet(ctx: *mut LewtonContext,
+											  pkt: *const u8, len: usize, sample_out: *mut *mut LewtonSamples) -> c_int {
+		unimplemented!()
+	}
+
+	/// Provide the number of samples present in each channel
+	#[no_mangle]
+    pub unsafe extern "C" fn lewton_samples_count(ctx: *const LewtonSamples) -> usize {
+		unimplemented!()
+	}
+
+	/// Provide a reference to the channel sample data
+	pub unsafe extern "C" fn lewton_samples_f32(samples: *mut LewtonSamples, channel: usize) -> *const f32 {
+		unimplemented!()
+	}
+
+	#[no_mangle]
+    pub unsafe extern "C" fn lewton_samples_drop(samples: *mut *mut LewtonSamples) {
+		unimplemented!()
+	}
+
+    #[no_mangle]
+    pub unsafe extern "C" fn lewton_context_drop(ctx: *mut *mut LewtonContext) {
+		unimplemented!()
+	}
+}
+
+#[cfg(cargo_c)]
+pub use capi::*;


### PR DESCRIPTION
To address https://github.com/RustAudio/lewton/issues/37 using [cargo-c](https://github.com/lu-zero/cargo-c) to make the process as transparent as possible (short of making a separate crate).

To test install [cargo-c](https://github.com/lu-zero/cargo-c) and run `cargo c install --destdir=/tmp/lewton-test/ to inspect its output.

[header](https://gist.github.com/lu-zero/f56acd4be0369a4331f531f9f1961bcd)
[pkg-config file](https://gist.github.com/lu-zero/01ad2739712dd25e34757523923dc544)
