### PR TITLE
Add a cbindgen.toml

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,0 +1,7 @@
+header = "// SPDX-License-Identifier: MIT OR Apache-2.0"
+sys_includes = ["stddef.h", "stdint.h", "stdlib.h"]
+no_includes = true
+include_guard = "LEWTON_LEWTON_H"
+tab_width = 4
+style = "Type"
+language = "C"


### PR DESCRIPTION
- Produce a C header instead of C++
- Report the license in the file