### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/lewton.yml
+++ b/.github/workflows/lewton.yml
@@ -1,0 +1,31 @@
+name: lewton
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, 1.20.0]
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup default ${{ matrix.rust }}
+        rustc -vV
+    - name: Run no-default-features builds
+      run: |
+        cargo build --verbose --no-default-features
+        cargo doc --verbose --no-default-features
+    - name: Run all-features builds
+      run: |
+        cargo build --verbose --all-features
+        cargo test --verbose
+        cargo doc --verbose --all-features
+    - name: Run cmp tests
+      run: |
+        cd dev/cmp
+        cargo test --verbose --release 


### PR DESCRIPTION
GitHub Actions allow to set `CI` directly into `GitHub`. This PR represents an alternative method to `travis`, but if you want to remove it completely, I can do it using this PR, no problem from my part.

Advantages
- Less time than `travis` (5 minutes instead of 9)
- Avoid using an external dependency

I've tried to replace all `cargo build` commands with the `cargo test` ones, but I got some building errors.  
Since `cargo` builds the crates before testing them, these replacements would decrease the number of steps maintaining the same results.
Do you want me to replace all of them in order to see the errors? Or do you prefer the current way?

Thanks in advance for your review! :) 