### PR TITLE
Workaround rust 1.38 pipelined compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ features = ["async_ogg"]
 
 [lib]
 name = "lewton"
+crate-type = ["lib", "staticlib"]


### PR DESCRIPTION
It breaks `cargo-c` otherwise.