### PR TITLE
Avoid allocating a vector in loop in `read_audio_packet_generic`

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -970,6 +970,7 @@ pub fn read_audio_packet_generic<S :Samples>(ident :&IdentHeader, setup :&SetupH
 		let mut ch = 0;
 		for (j, &mapping_mux_j) in mapping.mapping_mux.iter().enumerate() {
 			if mapping_mux_j as usize == i {
+				// TODO get rid of this copy somehow...
 				let vec_at_ch = &vectors[resid_vec_len * ch .. resid_vec_len * (ch + 1)];
 				residue_vectors[j].clear();
 				residue_vectors[j].extend_from_slice(vec_at_ch);

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -970,11 +970,9 @@ pub fn read_audio_packet_generic<S :Samples>(ident :&IdentHeader, setup :&SetupH
 		let mut ch = 0;
 		for (j, &mapping_mux_j) in mapping.mapping_mux.iter().enumerate() {
 			if mapping_mux_j as usize == i {
-				let mut v = Vec::with_capacity(resid_vec_len as usize);
 				let vec_at_ch = &vectors[resid_vec_len * ch .. resid_vec_len * (ch + 1)];
-				// TODO get rid of this copy somehow...
-				v.extend_from_slice(vec_at_ch);
-				residue_vectors[j] = v;
+				residue_vectors[j].clear();
+				residue_vectors[j].extend_from_slice(vec_at_ch);
 				ch += 1;
 			}
 		}


### PR DESCRIPTION
Fixes a TODO in code