### PR TITLE
Use 100% safe TinyVec instead of SmallVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "ogg 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinyvec 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -361,11 +361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "socket2"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +394,11 @@ dependencies = [
  "curl 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tokio-io"
@@ -531,11 +531,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e0cd9505afe45df2b8bdda585776281c7b29eb9d0e34b1e6dd2b12cba5d4ae1e"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-"checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 "checksum test-assets 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc2d8d670510507c128a1c1cd7a4337cf6a737199d0b602d10469e4c3c492959"
+"checksum tinyvec 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46a29940196b909d4797875c05ebd35b12fafeb2a25a98288a77c3ac8b93199d"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ required-features = ["ogg"]
 
 [dependencies]
 byteorder = "1.0"
-smallvec = "1.1"
+tinyvec = { version = "0.3.2", features = ["alloc"] }
 ogg = { version = "0.7", optional = true }
 tokio-io = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -18,7 +18,7 @@ use std::error;
 use std::fmt;
 use std::cmp::min;
 use std::iter;
-use smallvec::SmallVec;
+use tinyvec::TinyVec;
 use ::ilog;
 use ::bitpacking::BitpackCursor;
 use ::header::{Codebook, Floor, FloorTypeZero, FloorTypeOne,
@@ -932,7 +932,7 @@ pub fn read_audio_packet_generic<S :Samples>(ident :&IdentHeader, setup :&SetupH
 		&setup.codebooks, &setup.floors));
 
 	// Now calculate the no_residue vector
-	let mut no_residue = SmallVec::<[bool; 256]>::new();
+	let mut no_residue = TinyVec::<[bool; 32]>::new();
 	for fl in &decoded_floor_infos {
 		no_residue.push(fl.is_unused());
 	}
@@ -950,7 +950,7 @@ pub fn read_audio_packet_generic<S :Samples>(ident :&IdentHeader, setup :&SetupH
 	// Helper variable
 	let resid_vec_len = (n / 2) as usize;
 	for (i, &residue_number) in mapping.mapping_submap_residues.iter().enumerate() {
-		let mut do_not_decode_flag = SmallVec::<[bool; 256]>::new();
+		let mut do_not_decode_flag = TinyVec::<[bool; 32]>::new();
 		for (j, &mapping_mux_j) in mapping.mapping_mux.iter().enumerate() {
 			if mapping_mux_j as usize == i {
 				do_not_decode_flag.push(no_residue[j]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ modules.
 */
 
 extern crate byteorder;
-extern crate smallvec;
+extern crate tinyvec;
 #[cfg(feature = "ogg")]
 extern crate ogg;
 #[cfg(feature = "async_ogg")]


### PR DESCRIPTION
Switch from SmallVec to TinyVec, which is an implementation of the same idea but in 100% safe code. SmallVec has a [less-than-stellar track record](https://github.com/RustSec/advisory-db/tree/master/crates/smallvec) in terms of safety.

Sadly this drops the size of pre-allocated segment on the stack to 32 because Default is only implemented for arrays of size up to 32. This did not result in any measurable difference in performance on the samples I've thrown at it (speech, music, both short and long samples, low and high bitrates), but it's possible that I simply haven't found the right sample.