### PR TITLE
Remove the crate-type specifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,3 @@ features = ["async_ogg"]
 
 [lib]
 name = "lewton"
-crate-type = ["lib", "staticlib"]


### PR DESCRIPTION
The current versions of cargo-c do not have anymore that limitation and it might interact in surprising way if you pass certain flags to the compiler using `RUSTFLAGS`