### PR TITLE
Use u32::reverse_bits to reverse bits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,13 +171,7 @@ fn test_ilog() {
 }
 
 fn bit_reverse(n :u32) -> u32 {
-	// From the stb_vorbis implementation
-	let mut nn = n;
-	nn = ((nn & 0xAAAAAAAA) >> 1) | ((nn & 0x55555555) << 1);
-	nn = ((nn & 0xCCCCCCCC) >> 2) | ((nn & 0x33333333) << 2);
-	nn = ((nn & 0xF0F0F0F0) >> 4) | ((nn & 0x0F0F0F0F) << 4);
-	nn = ((nn & 0xFF00FF00) >> 8) | ((nn & 0x00FF00FF) << 8);
-	return (nn >> 16) | (nn << 16);
+	n.reverse_bits()
 }
 
 


### PR DESCRIPTION
I wanted to try running dev/cmp to bench but I ran into https://github.com/RustAudio/lewton/issues/89

I ran the perf example on bwv_542_fuge.ogg about 10 times with and without the change. This is a *horrible* way of doing this and probably meaningless, but I wanted to at least get some numbers before opening this issue. I would not really expect a perf regression from this, but just in case I feel like it should be benchmarked.

Max/min with change: 1.0420328 s/1.0198687 s
Max/min without change: 1.0231534 s/1.1075205 s