### PR TITLE
Refactor `OggStreamReader` and provide precise seek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,554 +4,550 @@
 name = "al-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8d9b0f4d10264c060ee5614dedb6b7695f366e93be6549c48f58981da39023"
 dependencies = [
- "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rental 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake",
+ "libloading",
+ "rental",
 ]
 
 [[package]]
 name = "alto"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75be812fc4f27ac66752f30715a2357c9f3ad619229fc21cf431b32606dfae5"
 dependencies = [
- "al-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "al-sys",
+ "lazy_static 0.2.11",
+ "parking_lot",
 ]
 
 [[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "bytes"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "iovec",
 ]
 
 [[package]]
 name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cmake"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 dependencies = [
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
 ]
 
 [[package]]
 name = "cmp"
 version = "0.1.0"
 dependencies = [
- "lewton 0.10.2",
- "test-assets 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vorbis 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lewton",
+ "test-assets",
+ "vorbis",
 ]
 
 [[package]]
 name = "curl"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06aa71e9208a54def20792d877bc663d6aae0732b9852e612c4a933177c31283"
 dependencies = [
- "curl-sys 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi",
 ]
 
 [[package]]
 name = "curl-sys"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c38ca47d60b86d0cc9d42caa90a0885669c2abc9791f871c81f58cdf39e979b"
 dependencies = [
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi",
 ]
 
 [[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lewton"
 version = "0.10.2"
 dependencies = [
- "alto 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "ogg 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tinyvec 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alto",
+ "byteorder",
+ "futures",
+ "ogg",
+ "tinyvec",
+ "tokio-io",
 ]
 
 [[package]]
 name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 
 [[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "winapi",
 ]
 
 [[package]]
 name = "libz-sys"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 dependencies = [
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
 
 [[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "ogg"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "bytes",
+ "futures",
+ "tokio-io",
 ]
 
 [[package]]
 name = "ogg-sys"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a95b8c172e17df1a41bf8d666301d3b2c4efeb90d9d0415e2a4dc0668b35fdb2"
 dependencies = [
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
 version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
 name = "owning_ref"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 dependencies = [
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "parking_lot"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 dependencies = [
- "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref",
+ "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "rand 0.4.6",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
 name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "rand 0.4.6",
 ]
 
 [[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 dependencies = [
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2",
 ]
 
 [[package]]
 name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "rental"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
 dependencies = [
- "rental-impl 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rental-impl",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "rental-impl"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "schannel"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0",
+ "winapi",
 ]
 
 [[package]]
 name = "sha2"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd9505afe45df2b8bdda585776281c7b29eb9d0e34b1e6dd2b12cba5d4ae1e"
 dependencies = [
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize",
 ]
 
 [[package]]
 name = "smallvec"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 dependencies = [
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "socket2"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
 ]
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "syn"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "test-assets"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2d8d670510507c128a1c1cd7a4337cf6a737199d0b602d10469e4c3c492959"
 dependencies = [
- "curl 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl",
+ "sha2",
 ]
 
 [[package]]
 name = "tinyvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
 dependencies = [
- "tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinyvec_macros",
 ]
 
 [[package]]
 name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio-io"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures",
+ "log",
 ]
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vorbis"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760993e54524128b88d4d7aff09c773c2f16a9f18db3c8ae1ccca5afd1287656"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "ogg-sys 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "vorbis-encoder 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vorbis-sys 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "vorbisfile-sys 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "ogg-sys",
+ "rand 0.3.23",
+ "vorbis-encoder",
+ "vorbis-sys",
+ "vorbisfile-sys",
 ]
 
 [[package]]
 name = "vorbis-encoder"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb66bcdde056dd230991bb86669a1269778fe8ad1f6cee403428ac7985391bc"
 dependencies = [
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "ogg-sys 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vorbis-sys 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc",
+ "libc",
+ "ogg-sys",
+ "pkg-config",
+ "vorbis-sys",
 ]
 
 [[package]]
 name = "vorbis-sys"
 version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729e1f15395850b4e6d19ca0cd1d42ef44707503a53b69d40ff49182b3c5589d"
 dependencies = [
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "ogg-sys 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc",
+ "libc",
+ "ogg-sys",
+ "pkg-config",
 ]
 
 [[package]]
 name = "vorbisfile-sys"
 version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4306d7e1ac4699b55e20de9483750b90c250913188efd7484db6bfbe9042d1"
 dependencies = [
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "ogg-sys 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vorbis-sys 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc",
+ "libc",
+ "ogg-sys",
+ "pkg-config",
+ "vorbis-sys",
 ]
 
 [[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum al-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8d9b0f4d10264c060ee5614dedb6b7695f366e93be6549c48f58981da39023"
-"checksum alto 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d75be812fc4f27ac66752f30715a2357c9f3ad619229fc21cf431b32606dfae5"
-"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
-"checksum curl 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)" = "06aa71e9208a54def20792d877bc663d6aae0732b9852e612c4a933177c31283"
-"checksum curl-sys 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)" = "0c38ca47d60b86d0cc9d42caa90a0885669c2abc9791f871c81f58cdf39e979b"
-"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
-"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-"checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-"checksum ogg 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
-"checksum ogg-sys 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a95b8c172e17df1a41bf8d666301d3b2c4efeb90d9d0415e2a4dc0668b35fdb2"
-"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-"checksum openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)" = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
-"checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-"checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
-"checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
-"checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
-"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
-"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum rental 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
-"checksum rental-impl 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-"checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
-"checksum sha2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e0cd9505afe45df2b8bdda585776281c7b29eb9d0e34b1e6dd2b12cba5d4ae1e"
-"checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-"checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
-"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
-"checksum test-assets 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc2d8d670510507c128a1c1cd7a4337cf6a737199d0b602d10469e4c3c492959"
-"checksum tinyvec 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
-"checksum tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-"checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
-"checksum vorbis 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "760993e54524128b88d4d7aff09c773c2f16a9f18db3c8ae1ccca5afd1287656"
-"checksum vorbis-encoder 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3fb66bcdde056dd230991bb86669a1269778fe8ad1f6cee403428ac7985391bc"
-"checksum vorbis-sys 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "729e1f15395850b4e6d19ca0cd1d42ef44707503a53b69d40ff49182b3c5589d"
-"checksum vorbisfile-sys 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4f4306d7e1ac4699b55e20de9483750b90c250913188efd7484db6bfbe9042d1"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ required-features = ["ogg"]
 [dependencies]
 byteorder = "1.0"
 tinyvec = { version = "1.0", features = ["alloc"] }
-ogg = { version = "0.8", optional = true }
+ogg = { version = "0.8", optional = true, path = "../ogg/" }
 tokio-io = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }
 
 [dev-dependencies]
-ogg = "0.8"
+ogg = { version = "0.8", path = "../ogg/" }
 alto = "3"
 
 [package.metadata.docs.rs]

--- a/src/header.rs
+++ b/src/header.rs
@@ -360,6 +360,7 @@ pub fn read_header_comment(packet :&[u8]) -> Result<CommentHeader, HeaderReadErr
 
 pub(crate) struct Codebook {
 	pub codebook_dimensions :u16,
+	#[allow(unused)]
 	pub codebook_entries :u32,
 
 	// None if codebook_lookup_type == 0
@@ -379,6 +380,7 @@ pub(crate) struct Residue {
 }
 
 pub(crate) struct Mapping {
+	#[allow(unused)]
 	pub mapping_submaps :u8,
 	pub mapping_magnitudes :Vec<u8>,
 	pub mapping_angles :Vec<u8>,
@@ -399,7 +401,9 @@ pub(crate) enum Floor {
 
 pub(crate) struct FloorTypeZero {
 	pub floor0_order :u8,
+	#[allow(unused)]
 	pub floor0_rate :u16,
+	#[allow(unused)]
 	pub floor0_bark_map_size :u16,
 	pub floor0_amplitude_bits :u8,
 	pub floor0_amplitude_offset :u8,

--- a/src/inside_ogg.rs
+++ b/src/inside_ogg.rs
@@ -385,6 +385,9 @@ impl <T: Read + Seek> SeekableOggStreamReader<T> {
 	pub fn inner_mut(&mut self) -> &mut OggStreamReader<T> {
 		&mut self.rdr
 	}
+	pub fn into_inner(self) -> OggStreamReader<T> {
+		self.rdr
+	}
 
 	/// Seeks to the specified absolute granule position, with a sample granularity.
 	///

--- a/src/inside_ogg.rs
+++ b/src/inside_ogg.rs
@@ -382,6 +382,9 @@ impl <T: Read + Seek> SeekableOggStreamReader<T> {
 		})
 	}
 
+	pub fn inner(&self) -> &mut OggStreamReader<T> {
+		&self.rdr
+	}
 	pub fn inner_mut(&mut self) -> &mut OggStreamReader<T> {
 		&mut self.rdr
 	}

--- a/src/inside_ogg.rs
+++ b/src/inside_ogg.rs
@@ -13,12 +13,13 @@ This module provides higher level access to the library functionality,
 and useful helper methods for the Ogg `PacketReader` struct.
 */
 
+use OggReadError;
 use ogg::{PacketReader, Packet};
 use header::*;
 use VorbisError;
-use std::io::{Read, Seek};
+use std::io::{Read, Seek, SeekFrom};
 use ::audio::{PreviousWindowRight, read_audio_packet,
-	read_audio_packet_generic};
+	read_audio_packet_generic, get_decoded_sample_count};
 use ::header::HeaderSet;
 use ::samples::{Samples, InterleavedSamples};
 
@@ -27,136 +28,189 @@ use ::samples::{Samples, InterleavedSamples};
 /// Please note that this function doesn't work well with async
 /// I/O. In order to support this use case, enable the `async_ogg` feature,
 /// and use the `HeadersReader` struct instead.
-pub fn read_headers<'a, T: Read + Seek + 'a>(rdr: &mut PacketReader<T>) ->
+pub fn read_headers<'a, T: Read + 'a>(rdr: &mut PacketReader<T>) ->
 		Result<(HeaderSet, u32), VorbisError> {
-	let pck :Packet = try!(rdr.read_packet_expected());
+	let ident_packet = try!(rdr.read_packet_expected());
+	let (headers, stream_serial, _stream_ends) =
+		try!(read_headers_with_ident_packet(rdr, ident_packet));
+	Ok((headers, stream_serial))
+}
+
+fn read_headers_with_ident_packet<'a, T>(
+	mut rdr: &mut PacketReader<T>,
+	ident_packet: Packet,
+) -> Result<(HeaderSet, u32, bool), VorbisError>
+where
+	T: Read + 'a,
+{
+	let pck :Packet = ident_packet;
 	let ident_hdr = try!(read_header_ident(&pck.data));
 	let stream_serial = pck.stream_serial();
 
-	let mut pck :Packet = try!(rdr.read_packet_expected());
-	while pck.stream_serial() != stream_serial {
-		pck = try!(rdr.read_packet_expected());
-	}
+	let pck :Packet = try!(read_expected_packet_with_stream_serial(&mut rdr, stream_serial));
 	let comment_hdr = try!(read_header_comment(&pck.data));
 
-	let mut pck :Packet = try!(rdr.read_packet_expected());
-	while pck.stream_serial() != stream_serial {
-		pck = try!(rdr.read_packet_expected());
-	}
+	let pck :Packet = try!(read_expected_packet_with_stream_serial(&mut rdr, stream_serial));
 	let setup_hdr = try!(read_header_setup(&pck.data, ident_hdr.audio_channels,
 		(ident_hdr.blocksize_0, ident_hdr.blocksize_1)));
 
+	// The first audio packet must begin on a fresh page
+	// TODO: do we really need this?
 	rdr.delete_unread_packets();
-	return Ok(((ident_hdr, comment_hdr, setup_hdr), pck.stream_serial()));
+	Ok((
+		(ident_hdr, comment_hdr, setup_hdr),
+		pck.stream_serial(),
+		pck.last_in_stream(),
+	))
+}
+
+fn read_expected_packet_with_stream_serial<R: Read>(
+	reader :&mut PacketReader<R>, stream_serial: u32
+) -> Result<Packet, VorbisError> {
+	loop {
+		let packet = try!(reader.read_packet_expected());
+		if packet.stream_serial() == stream_serial {
+			return Ok(packet);
+		}
+	}
 }
 
 /**
-Reading ogg/vorbis files or streams
+Reading an ogg/vorbis stream
 
-This is a small helper struct to help reading ogg/vorbis files
-or streams in that format.
+This is a small helper struct to help reading an ogg/vorbis stream in that format.
 
-It only supports the main use case of pure audio ogg files streams.
-Reading a file where vorbis is only one of multiple streams, like
-in the case of ogv, is not supported.
+It only supports the main use case of unmultiplexed, pure audio ogg files streams.
+Reading a file where vorbis is only one of multiplexed streams, like in the case of ogv, is not supported.
+(The packet that does not belong to the stream are skipped.)
+If you need support for this, you need to use the lower level methods instead.
 
-If you need support for this, you need to use the lower level methods
-instead.
+This struct only takes care of a single logical audio stream.
+After reaching the end of a stream,
+`read_dec_packet_*` functions do no longer return any audio,
+even if there are another stream awaiting.
+You can obtain another `OggStreamReader` via `` function, if any.
 */
-pub struct OggStreamReader<T: Read + Seek> {
+pub struct OggStreamReader<T: Read> {
 	rdr :PacketReader<T>,
 	pwr :PreviousWindowRight,
 
 	stream_serial :u32,
 
-	pub ident_hdr :IdentHeader,
-	pub comment_hdr :CommentHeader,
-	pub setup_hdr :SetupHeader,
+	ident_hdr :IdentHeader,
+	comment_hdr :CommentHeader,
+	setup_hdr :SetupHeader,
 
-	cur_absgp :Option<u64>,
+	state: ReaderState,
+	skip_count: u64,
+	start_absgp: u64,
+	cur_absgp: u64,
+
+	next_packet: Option<Packet>,
 }
 
-impl<T: Read + Seek> OggStreamReader<T> {
-	/// Constructs a new OggStreamReader from a given implementation of `Read + Seek`.
+enum ReaderState {
+	Processing,
+	Finished,
+}
+
+impl<T: Read> OggStreamReader<T> {
+	/// Constructs a new OggStreamReader from a given implementation of `Read`.
 	///
-	/// Please note that this function doesn't work well with async
-	/// I/O. In order to support this use case, enable the `async_ogg` feature,
+	/// Please note that this function doesn't work well with async I/O.
+	/// In order to support this use case, enable the `async_ogg` feature,
 	/// and use the `HeadersReader` struct instead.
-	pub fn new(rdr :T) ->
-			Result<Self, VorbisError> {
-		OggStreamReader::from_ogg_reader(PacketReader::new(rdr))
+	pub fn new(rdr :T) -> Result<Self, VorbisError> {
+		Self::from_ogg_reader(PacketReader::new(rdr))
 	}
+
 	/// Constructs a new OggStreamReader from a given Ogg PacketReader.
 	///
 	/// The `new` function is a nice wrapper around this function that
 	/// also creates the ogg reader.
 	///
-	/// Please note that this function doesn't work well with async
-	/// I/O. In order to support this use case, enable the `async_ogg` feature,
+	/// Please note that this function doesn't work well with async I/O.
+	/// In order to support this use case, enable the `async_ogg` feature,
 	/// and use the `HeadersReader` struct instead.
-	pub fn from_ogg_reader(mut rdr :PacketReader<T>) ->
-			Result<Self, VorbisError> {
-		let ((ident_hdr, comment_hdr, setup_hdr), stream_serial) =
-			try!(read_headers(&mut rdr));
-		return Ok(OggStreamReader {
+	pub fn from_ogg_reader(mut rdr :PacketReader<T>) -> Result<Self, VorbisError> {
+		let ident_packet = try!(rdr.read_packet_expected());
+		Self::from_ogg_reader_and_previous_packet(rdr, ident_packet, |_| {})
+			.map(|x| x.0)
+	}
+
+	fn from_ogg_reader_and_previous_packet<F, R>(
+		mut rdr: PacketReader<T>,
+		ident_packet: Packet,
+		mut after_reading_header: F,
+	) -> Result<(Self, R), VorbisError>
+	where
+		F: FnMut(&mut PacketReader<T>) -> R,
+	{
+		let ((ident_hdr, comment_hdr, setup_hdr), stream_serial, no_more_packets) =
+			try!(read_headers_with_ident_packet(&mut rdr, ident_packet));
+		let after_reading_header = after_reading_header(&mut rdr);
+
+		let mut reader = OggStreamReader {
 			rdr,
-			pwr : PreviousWindowRight::new(),
+			pwr: PreviousWindowRight::new(),
 			ident_hdr,
 			comment_hdr,
 			setup_hdr,
 			stream_serial,
-			cur_absgp : None,
-		});
+			// The following fields will be overwritten for normal initialization
+			// (for stream with no less than two packets)
+			state: ReaderState::Finished,
+			skip_count: 0,
+			start_absgp: 0,
+			cur_absgp: 0,
+			next_packet: None,
+		};
+
+		// If there are less than two audio packets, we cannot obtain any samples.
+		// TODO I am not sure this is compliant with spec
+		if no_more_packets {
+			// There are zero audio packets.
+			return Ok((reader, after_reading_header));
+		}
+		let first_packet = try!(read_expected_packet_with_stream_serial(&mut reader.rdr, stream_serial));
+		if first_packet.last_in_stream() {
+			// There is one audio packet.
+			return Ok((reader, after_reading_header));
+		}
+		// Decode the first packet into pwr.
+		try!(read_audio_packet(&reader.ident_hdr, &reader.setup_hdr, &first_packet.data, &mut reader.pwr));
+		// The second packet will actually be parsed later.
+		try!(reader.load_second_audio_packet());
+
+		Ok((reader, after_reading_header))
 	}
+
+	/// Read the second packet in a logical stream and adjust skip_count.
+	/// The second packet must exist.
+	fn load_second_audio_packet(&mut self) -> Result<(), VorbisError> {
+		let second_packet = try!(read_expected_packet_with_stream_serial(&mut self.rdr, self.stream_serial));
+		let second_packet_sample_count =
+			try!(get_decoded_sample_count(&self.ident_hdr, &self.setup_hdr, &second_packet.data)) as u64;
+
+		// Since the third audio packet will start in a fresh page,
+		// we can always assume that the absgp for this page as that of the second one.
+		let skip_count = second_packet_sample_count.saturating_sub(second_packet.absgp_page());
+		let start_absgp = second_packet.absgp_page().saturating_sub(second_packet_sample_count);
+		assert_eq!(start_absgp + skip_count + second_packet_sample_count, second_packet.absgp_page());
+
+		self.skip_count = skip_count;
+		self.start_absgp = start_absgp;
+		self.cur_absgp = start_absgp;
+		self.next_packet = Some(second_packet);
+
+		Ok(())
+	}
+
+	/// Returns the wrapped reader, consuming the `OggStreamReader`.
 	pub fn into_inner(self) -> PacketReader<T> {
 		self.rdr
 	}
-	fn read_next_audio_packet(&mut self) -> Result<Option<Packet>, VorbisError> {
-		loop {
-			let pck = match try!(self.rdr.read_packet()) {
-				Some(p) => p,
-				None => return Ok(None),
-			};
-			if pck.stream_serial() != self.stream_serial {
-				if pck.first_in_stream() {
-					// We have a chained ogg file. This means we need to
-					// re-initialize the internal context.
-					let ident_hdr = try!(read_header_ident(&pck.data));
 
-					let pck :Packet = try!(self.rdr.read_packet_expected());
-					let comment_hdr = try!(read_header_comment(&pck.data));
-
-					let pck :Packet = try!(self.rdr.read_packet_expected());
-					let setup_hdr = try!(read_header_setup(&pck.data, ident_hdr.audio_channels,
-						(ident_hdr.blocksize_0, ident_hdr.blocksize_1)));
-
-					// Update the context
-					self.pwr = PreviousWindowRight::new();
-					self.ident_hdr = ident_hdr;
-					self.comment_hdr = comment_hdr;
-					self.setup_hdr = setup_hdr;
-					self.stream_serial = pck.stream_serial();
-					self.cur_absgp = None;
-
-					// Now, read the first audio packet to prime the pwr
-					// and discard the packet.
-					let pck = match try!(self.rdr.read_packet()) {
-						Some(p) => p,
-						None => return Ok(None),
-					};
-					let _decoded_pck = try!(read_audio_packet(&self.ident_hdr,
-						&self.setup_hdr, &pck.data, &mut self.pwr));
-					self.cur_absgp = Some(pck.absgp_page());
-
-					return Ok(try!(self.rdr.read_packet()));
-				} else {
-					// Ignore every packet that has a mismatching stream serial
-				}
-			} else {
-				return Ok(Some(pck));
-			}
-		}
-	}
 	/// Reads and decompresses an audio packet from the stream.
 	///
 	/// On read errors, it returns Err(e) with the error.
@@ -169,6 +223,7 @@ impl<T: Read + Seek> OggStreamReader<T> {
 		let pck = try!(self.read_dec_packet_generic());
 		Ok(pck)
 	}
+
 	/// Reads and decompresses an audio packet from the stream (generic).
 	///
 	/// On read errors, it returns Err(e) with the error.
@@ -176,28 +231,59 @@ impl<T: Read + Seek> OggStreamReader<T> {
 	/// On success, it either returns None, when the end of the
 	/// stream has been reached, or Some(packet_data),
 	/// with the data of the decompressed packet.
-	pub fn read_dec_packet_generic<S :Samples>(&mut self) ->
-			Result<Option<S>, VorbisError> {
-		let pck = match try!(self.read_next_audio_packet()) {
-			Some(p) => p,
-			None => return Ok(None),
+	pub fn read_dec_packet_generic<S :Samples>(&mut self) -> Result<Option<S>, VorbisError> {
+		let pck = if let Some(next_packet) = self.next_packet.take() {
+			next_packet
+		} else {
+			try!(read_expected_packet_with_stream_serial(&mut self.rdr, self.stream_serial))
 		};
-		let mut decoded_pck :S = try!(read_audio_packet_generic(&self.ident_hdr,
-			&self.setup_hdr, &pck.data, &mut self.pwr));
+		let mut decoded_pck :S = try!(read_audio_packet_generic(
+				&self.ident_hdr, &self.setup_hdr, &pck.data, &mut self.pwr));
 
-		// If this is the last packet in the logical bitstream,
-		// we need to truncate it so that its ending matches
-		// the absgp of the current page.
-		// This is what the spec mandates and also the behaviour
-		// of libvorbis.
-		if let (Some(absgp), true) = (self.cur_absgp, pck.last_in_stream()) {
-			let target_length = pck.absgp_page().saturating_sub(absgp) as usize;
-			decoded_pck.truncate(target_length);
+		// TODO the following comment is wrong
+		// TODO If there was only two audio packets in a logical stream,
+		// and the absgp for the second one is less than the number of samples retrieved from them,
+		// then the current code truncate the beginning, not the ending.
+		// But is it the correct way to do so?
+		// I couldn't found any information about that in the spec.
+		// Also this means that, if we want to indicate a positive initial absgp,
+		// then we cannot truncate the trailing samepls,
+		// thus cannot represent an audio whose number of samples are less than
+		// short_block_length / 2.
+		// Or can we?
+
+		// TODO maybe we should remove the following comment
+			// If this is the first packet in the logical stream,
+			// we need to truncate the beginning so that its ending matches the absgp of the current page.
+
+		// The leading samples are skipped after parsing the second audio packet for a logical stream,
+		// or after seeking.
+		let skip_count = self.skip_count.min(decoded_pck.num_samples() as u64);
+		self.skip_count -= skip_count;
+		decoded_pck.truncate_begin(skip_count as usize);
+
+		if pck.last_in_stream() {
+			if self.skip_count == 0 {
+				// If this is the last packet in the logical bitstream,
+				// we need to truncate it so that its ending matches the absgp of the current page.
+				// This is what the spec mandates and also the behaviour of libvorbis.
+				let truncate_size = (self.cur_absgp + decoded_pck.num_samples() as u64)
+					.saturating_sub(pck.absgp_page());
+				decoded_pck.truncate(truncate_size as usize);
+			}
+			// If skip count is non-zero, then it means that a seek beyond
+
+			self.state = ReaderState::Finished;
 		}
+
+		self.cur_absgp += decoded_pck.num_samples() as u64;
 		if pck.last_in_page() {
-			self.cur_absgp = Some(pck.absgp_page());
-		} else if let &mut Some(ref mut absgp) = &mut self.cur_absgp {
-			*absgp += decoded_pck.num_samples() as u64;
+			if pck.absgp_page() != self.cur_absgp {
+				// Should we do something else?
+				// At least, it may not be a good idea to panic,
+				// since the input file is subject to corruption.
+				eprintln!("cur_absgp does not match.  Provided: {}, calculated: {}", pck.absgp_page(), self.cur_absgp);
+			}
 		}
 
 		return Ok(Some(decoded_pck));
@@ -228,27 +314,135 @@ impl<T: Read + Seek> OggStreamReader<T> {
 		self.stream_serial
 	}
 
-	/// Returns the absolute granule position of the last read page.
+	pub fn start_absgp(&self) -> u64 {
+		self.start_absgp
+	}
+	/// Returns the absolute granule position of the last read packet.
 	///
-	/// In the case of ogg/vorbis, the absolute granule position is given
-	/// as number of PCM samples, on a per channel basis.
-	pub fn get_last_absgp(&self) -> Option<u64> {
+	/// In the case of ogg/vorbis,
+	/// the absolute granule position is given as number of PCM samples, on a per channel basis
+	/// (that is, "a stereo stream’s granule position does not increment at twice the speed of a mono stream").
+	pub fn cur_absgp(&self) -> u64 {
 		self.cur_absgp
 	}
 
-	/// Seeks to the specified absolute granule position, with a page granularity.
+	pub fn ident_hdr(&self) -> &IdentHeader {
+		&self.ident_hdr
+	}
+
+	pub fn comment_hdr(&self) -> &CommentHeader {
+		&self.comment_hdr
+	}
+
+	pub fn setup_hdr(&self) -> &SetupHeader {
+		&self.setup_hdr
+	}
+}
+
+pub struct SeekableOggStreamReader<T: Read + Seek> {
+	rdr: OggStreamReader<T>,
+	stream_start_pos: u64,
+	audio_packet_start_pos: u64,
+	stream_end_pos: Option<u64>,
+}
+
+impl <T: Read + Seek> SeekableOggStreamReader<T> {
+	pub fn new(mut rdr: T) -> Result<Self, VorbisError> {
+		let map_io_error = |e| VorbisError::OggError(OggReadError::ReadError(e));
+
+		let stream_start_pos = try!(rdr.seek(SeekFrom::Current(0)).map_err(map_io_error));
+		let mut packet_reader = PacketReader::new(rdr);
+		let ident_packet = try!(packet_reader.read_packet_expected());
+		let (ogg_stream_reader, audio_strea_start_pos) = try!(OggStreamReader::from_ogg_reader_and_previous_packet(
+			packet_reader,
+			ident_packet,
+			|rdr| rdr.seek_bytes(SeekFrom::Current(0)),
+		));
+
+		Ok(Self {
+			rdr: ogg_stream_reader,
+			stream_start_pos,
+			audio_packet_start_pos: try!(audio_strea_start_pos.map_err(map_io_error)),
+			stream_end_pos: None,
+		})
+	}
+
+	pub fn inner_mut(&mut self) -> &mut OggStreamReader<T> {
+		&mut self.rdr
+	}
+
+	/// Seeks to the specified absolute granule position, with a sample granularity.
 	///
-	/// The granularity is per-page, and the obtained position is
-	/// then <= the seeked absgp.
+	/// If the provided absgp was less than (or equal to) `start_absgp`,
+	/// then it seeks to the beginning of the logical stream.
 	///
-	/// In the case of ogg/vorbis, the absolute granule position is given
-	/// as number of PCM samples, on a per channel basis.
-	pub fn seek_absgp_pg(&mut self, absgp :u64) -> Result<(), VorbisError> {
-		try!(self.rdr.seek_absgp(None, absgp));
-		// Reset the internal state after the seek
-		self.cur_absgp = None;
-		self.pwr = PreviousWindowRight::new();
+	/// In the case of ogg/vorbis,
+	/// the absolute granule position is given as number of PCM samples, on a per channel basis
+	/// (that is, "a stereo stream’s granule position does not increment at twice the speed of a mono stream").
+	///
+	/// This function assumes unmultiplexed streams.
+	pub fn seek_absgp(&mut self, absgp :u64) -> Result<(), VorbisError> {
+		self.rdr.pwr = PreviousWindowRight::new();
+		let search_range = self.audio_packet_start_pos..try!(self.stream_end_pos());
+		let target_absgp = absgp.saturating_sub(self.rdr.ident_hdr.blocksize_1 as u64/ 2);
+		let seeked_absgp = try!(self.rdr.rdr.seek_absgp_new(
+				target_absgp, Some(self.rdr.stream_serial), search_range));
+
+		let first_packet = match try!(self.rdr.rdr.read_packet()).and_then(|packet| {
+			if packet.stream_serial() == self.rdr.stream_serial {
+				Some(packet)
+			} else {
+				// If the stream serial of the next packet does not match,
+				// then we assume that that is the start of another stream.
+				self.rdr.next_packet = Some(packet);
+				None
+			}
+		}) {
+			None => {
+				// We seeked to the end of logical stream.
+				self.rdr.state = ReaderState::Finished;
+				if let Some(seeked_absgp) = seeked_absgp {
+					// seeked_absgp is None only if there were no audio packet.
+					self.rdr.cur_absgp = seeked_absgp;
+				}
+				return Ok(());
+			}
+			Some(packet) => packet
+		};
+		// Decode the first packet into pwr.
+		try!(read_audio_packet(&self.rdr.ident_hdr, &self.rdr.setup_hdr, &first_packet.data, &mut self.rdr.pwr));
+		let first_packet_sample_count =
+			try!(get_decoded_sample_count(&self.rdr.ident_hdr, &self.rdr.setup_hdr, &first_packet.data)) as u64;
+
+		self.rdr.state = ReaderState::Processing;
+		self.rdr.cur_absgp = absgp;
+		match seeked_absgp {
+			Some(seeked_absgp) => {
+				self.rdr.skip_count = absgp - seeked_absgp - first_packet_sample_count;
+			}
+			None => {
+				try!(self.rdr.load_second_audio_packet());
+				// In addition to discarding the first samples,
+				// we should additionally seeek to the specified position.
+				self.rdr.skip_count += absgp.saturating_sub(self.rdr.start_absgp);
+			}
+		};
+
 		Ok(())
+	}
+
+	fn stream_end_pos(&mut self) -> Result<u64, OggReadError> {
+		let pos = match self.stream_end_pos {
+			Some(pos) => pos,
+			None => {
+				try!(self.rdr.rdr.seek_bytes(SeekFrom::Start(self.stream_start_pos)));
+				let pos = try!(self.rdr.rdr.find_end_of_logical_stream());
+				let pos = pos.expect("There should be at least one packet after stream_start_pos");
+				self.stream_end_pos = Some(pos);
+				pos
+			}
+		};
+		Ok(pos)
 	}
 }
 

--- a/src/inside_ogg.rs
+++ b/src/inside_ogg.rs
@@ -205,6 +205,10 @@ impl<T: Read> OggStreamReader<T> {
 			self.skip_count = skip_count;
 			self.start_absgp = start_absgp;
 			self.cur_absgp = start_absgp;
+		} else {
+			self.skip_count = 0;
+			self.start_absgp = 0;
+			self.cur_absgp = 0;
 		}
 		self.state = ReaderState::Processing;
 		self.next_packet = Some(second_packet);
@@ -408,7 +412,7 @@ impl <T: Read + Seek> SeekableOggStreamReader<T> {
 		let target_absgp = absgp.saturating_sub(1 << self.rdr.ident_hdr.blocksize_1);
 		let seeked_absgp = try!(self.rdr.rdr.seek_absgp_new(
 				target_absgp, Some(self.rdr.stream_serial), search_range));
-		// dbg!(target_absgp, seeked_absgp);
+		// dbg!(absgp, self.audio_packet_start_pos..try!(self.stream_end_pos()), target_absgp, seeked_absgp);
 
 		let first_packet = match try!(self.rdr.rdr.read_packet()).and_then(|packet| {
 			if packet.stream_serial() == self.rdr.stream_serial {
@@ -449,7 +453,7 @@ impl <T: Read + Seek> SeekableOggStreamReader<T> {
 				self.rdr.skip_count += absgp.saturating_sub(self.rdr.start_absgp);
 			}
 		};
-		// dbg!(first_packet_sample_count, self.rdr.skip_count);
+		// dbg!(self.rdr.skip_count);
 
 		Ok(())
 	}

--- a/src/inside_ogg.rs
+++ b/src/inside_ogg.rs
@@ -382,7 +382,7 @@ impl <T: Read + Seek> SeekableOggStreamReader<T> {
 		})
 	}
 
-	pub fn inner(&self) -> &mut OggStreamReader<T> {
+	pub fn inner(&self) -> &OggStreamReader<T> {
 		&self.rdr
 	}
 	pub fn inner_mut(&mut self) -> &mut OggStreamReader<T> {

--- a/src/samples.rs
+++ b/src/samples.rs
@@ -14,6 +14,7 @@ Traits for sample formats
 pub trait Samples {
 	fn num_samples(&self) -> usize;
 	fn truncate(&mut self, limit :usize);
+    fn truncate_begin(&mut self, len: usize);
 	fn from_floats(floats :Vec<Vec<f32>>) -> Self;
 }
 
@@ -28,6 +29,11 @@ impl<S :Sample> Samples for Vec<Vec<S>> {
 			}
 		}
 	}
+    fn truncate_begin(&mut self, len: usize) {
+        for samples in self.iter_mut() {
+            samples.drain(..samples.len().min(len));
+        }
+    }
 
 	fn from_floats(floats :Vec<Vec<f32>>) -> Self {
 		floats.into_iter()
@@ -52,6 +58,9 @@ impl<S :Sample> Samples for InterleavedSamples<S> {
 	fn truncate(&mut self, limit :usize) {
 		self.samples.truncate(limit * self.channel_count);
 	}
+    fn truncate_begin(&mut self, len: usize) {
+        self.samples.drain(..len * self.channel_count);
+    }
 	fn from_floats(floats :Vec<Vec<f32>>) -> Self {
 		let channel_count = floats.len();
 		// Note that a channel count of 0 is forbidden


### PR DESCRIPTION
Current `OggStreamReader` has several issues:

* We cannot seek the stream at sample-level (closes #16)
* `get_last_absgp` provides insufficient information in some case (closes #84) and may not work for chained streams (closes #87)
* Header fields are public, and subject to unwanted change (closes #85)
* Behavior for multiplexed streams is unclear (closes #86)
* ~We cannot obtain the length of stream~ (#95): this is still unimplemented
* It won't drop the samples in the first packet even when needed (which is required by [spec](https://xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-132000A.2))
* It always requires `Seek` (Rustaudio/rodio#333) (Well, I know you may disagree about this)

So I implemented a sample-level seek.


### Changes in API

* `OggStreamReader` does no longer require `io::Seek`.  Therefore it does not provide `seek_absgp_pg`.
* Instead, new struct `SeekableOggStreamReader` is provided.  This struct comes with `seek_absgp`, where users can seek the reader in sample-level.
  * I had to keep those two structs separate because we need to do the different initialization steps and fields for seekable and unseekable reader (in specific, record the stream bounds).
* `OggStreamReader` and `SeekableOggStreamReader` is dedicated to only a single stream.  If you want to parse chained stream, you have to create a new one.
     * Later, I'm going to implement some function like `next_stream(self) -> Option<OggStreamReader>` that consumes the reader, checks if the next packet exists, and returns if exists.
 * `ident_hdr`, `comment_hdr`, and `setup_hdr` is no longer public.  Now they can be accessed only immutably through the corresponding getter functions.
 
### Issues & Future Task

One major issue is that the page absgp in real-world ogg/vorbis file often contains errors.  Specifically, each of the ogg files I have has 3-20 errors, classified to the following two types:
* When a page ends with a "long" block and the next page starts with "short" block, then the `absgp` for the former page is wrong.  In specific, all of the ogg files I have use "long" blocks of length 2048 and "short" blocks of length 512, and the absgp for the former page sometimes differs by 448.  This type of error was found in almost all the ogg files I have.
* The absgp for the last page is less than the number of total samples obtained from the entire stream, subtracted by the number of samples obtained from the last packet.  The spec requires to drop the last few frames from the **final** packet according to the absgp provided in the page, as quoted below, but it seems that real-word ogg files requires to drop more samples.
> A granule position on the final page in a stream that indicates less audio data than the final packet would normally return is used to end the stream on other than even frame boundaries

If the absgp provided in the pages has an error, then the seek result may be wrong, especially for the first type of error mentioned above.  I'm now wondering that I've mistook some spec of the Vorbis stream, or this is the bug of many Vorbis encoders (all I have of which is based on libvorbis by the way).
Yeah, it's only 448 frames in ~44100 fps data, so the diff is 0.01 seconds, so we may not have to care about that though.

Speaking about the incompatibility with the spec, I also realized that most of the ogg files does not follow the spec that " the second finished audio packet must flush the page on which it appears and the third packet begin a fresh page".  I implemented the dropping-leading-samples features based on this fact, but it does not actually run for most of the files.  Anyway I followed the another requirement in the spec that "Failure to do so should, at worst, cause a decoder implementation to return incorrect positioning information for seeking operations at the very beginning of the stream".   At any rate, most of the ogg files starts with absgp 0, which means that we don't have to drop the initial frames at all.

Here are the other tasks and concerns:

* Only [informal test](https://gist.github.com/TonalidadeHidrica/3f2ac116b00399c298909635ed3d3655#file-test_seek-rs) is done yet for the new seeking function.  Maybe should I include it in this repository as a test?
  * Also, it is not yet tested against chained / multiplexed streams.
* I have not checked the compatibility with `async` feature yet.
* I didn't encountered an audio packet spanning more than one page, so there may be a bug for that case.
* The code may not compile with MSRV.

And here are the issues I'll handle at last:

* The code may not be well-formatted.
* The commits are not rebased yet.