### PR TITLE
Switch to using smallvec over tinyvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "byteorder",
  "futures",
  "ogg",
- "tinyvec",
+ "smallvec 1.8.0",
  "tokio-io",
 ]
 
@@ -275,7 +275,7 @@ checksum = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 dependencies = [
  "libc",
  "rand 0.4.6",
- "smallvec",
+ "smallvec 0.6.13",
  "winapi",
 ]
 
@@ -406,6 +406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
 name = "socket2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,21 +448,6 @@ dependencies = [
  "curl",
  "sha2",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio-io"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ required-features = ["ogg"]
 
 [dependencies]
 byteorder = "1.0"
-tinyvec = { version = "1.0", features = ["alloc"] }
+smallvec= { version = "1.0" }
 ogg = { version = "0.8", optional = true }
 tokio-io = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -16,7 +16,7 @@ use std::error;
 use std::fmt;
 use std::cmp::min;
 use std::iter;
-use tinyvec::TinyVec;
+use smallvec::SmallVec;
 use crate::ilog;
 use bitpacking::BitpackCursor;
 use header::{Codebook, Floor, FloorTypeZero, FloorTypeOne,
@@ -940,7 +940,7 @@ pub fn read_audio_packet_generic<S :Samples>(ident :&IdentHeader, setup :&SetupH
 		&setup.codebooks, &setup.floors));
 
 	// Now calculate the no_residue vector
-	let mut no_residue = TinyVec::<[bool; 32]>::new();
+	let mut no_residue = SmallVec::<[bool; 32]>::new();
 	for fl in &decoded_floor_infos {
 		no_residue.push(fl.is_unused());
 	}
@@ -958,7 +958,7 @@ pub fn read_audio_packet_generic<S :Samples>(ident :&IdentHeader, setup :&SetupH
 	// Helper variable
 	let resid_vec_len = (n / 2) as usize;
 	for (i, &residue_number) in mapping.mapping_submap_residues.iter().enumerate() {
-		let mut do_not_decode_flag = TinyVec::<[bool; 32]>::new();
+		let mut do_not_decode_flag = SmallVec::<[bool; 32]>::new();
 		for (j, &mapping_mux_j) in mapping.mapping_mux.iter().enumerate() {
 			if mapping_mux_j as usize == i {
 				do_not_decode_flag.push(no_residue[j]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ modules.
 */
 
 extern crate byteorder;
-extern crate tinyvec;
+extern crate smallvec;
 #[cfg(feature = "ogg")]
 extern crate ogg;
 #[cfg(feature = "async_ogg")]


### PR DESCRIPTION
`smallvec` seems to be in much higher use than `tinyvec`, so adding `tinyvec` tends to increase the amount of work while using `lewton` as a dependency in a typical build. This PR replaces `tinyvec` with `smallvec` as a drop-in replacement.